### PR TITLE
phpファイルの差分の箇所のみ、phpcsでチェックする

### DIFF
--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -24,3 +24,5 @@ jobs:
         run: echo "changed_files=$(git diff --name-only origin/${{ github.base_ref }} HEAD -- '*.php')" >> $GITHUB_OUTPUT
       - name: Echo # 後々削除
         run: echo ${{ steps.git-diff-changed-files.outputs.changed_files }}
+      - name: Run phpcs
+        run: phpcs -q --report=checkstyle --standard=PSR12 ${{ steps.git-diff-changed-files.outputs.changed_files }}

--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -1,4 +1,5 @@
 name: PHP CS for diff lines
+run-name: Pushed to ${{ github.event.pull_request.title }} by ${{ github.actor }}
 
 on:
   pull_request:

--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -35,6 +35,7 @@ jobs:
   checkstyle_filter-git:
     # name:
     runs-on: ubuntu-latest
+    needs: php-cs
     steps:
       - uses: actions/checkout@v3 # 必要？
       - name: Set up Ruby

--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -10,6 +10,8 @@ jobs:
   php-cs:
     name: PHP CS of changed files
     runs-on: ubuntu-latest
+    outputs:
+      outputs-on-phpcs: ${{ steps.reported-checkstyle-with-phpcs.outputs.reported-checkstyle }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup PHP
@@ -25,4 +27,5 @@ jobs:
       - name: Echo # 後々削除
         run: echo ${{ steps.git-diff-changed-files.outputs.changed_files }}
       - name: Run phpcs
-        run: phpcs -q --report=checkstyle --standard=PSR12 ${{ steps.git-diff-changed-files.outputs.changed_files }}
+        id: reported-checkstyle-with-phpcs
+        run: echo "reported-checkstyle=$(phpcs -q --report=checkstyle --standard=PSR12 ${{ steps.git-diff-changed-files.outputs.changed_files }})" >> $GITHUB_OUTPUT

--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -30,7 +30,7 @@ jobs:
         id: reported-checkstyle-with-phpcs
         run: |
           echo 'reported-checkstyle<<EOF' >> $GITHUB_OUTPUT
-          echo "$(phpcs -q --report=checkstyle --standard=PSR12 ${{ steps.git-diff-changed-files.outputs.changed_files }})" >> $GITHUB_OUTPUT
+          echo $(phpcs -q --report=checkstyle --standard=PSR12 ${{ steps.git-diff-changed-files.outputs.changed_files }}) >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
   checkstyle_filter-git:
     # name:

--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -19,6 +19,12 @@ jobs:
         with:
           php-version: '8.1'
           tools: cs2pr, phpcs # cs2prいらんか？
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.0'
+      - name: Install checkstyle_filter-git
+        run: gem install checkstyle_filter-git
       - name: Fetch
         run: git fetch origin ${{ github.base_ref }} --depth=1
       - name: Git diff
@@ -29,20 +35,5 @@ jobs:
       - name: Run phpcs
         id: reported-checkstyle-with-phpcs
         run: |
-          echo 'reported-checkstyle<<EOF' >> $GITHUB_OUTPUT
-          echo "$(phpcs -q --report=checkstyle --standard=PSR12 ${{ steps.git-diff-changed-files.outputs.changed_files }})" >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
-  checkstyle_filter-git:
-    # name:
-    runs-on: ubuntu-latest
-    needs: php-cs
-    steps:
-      - uses: actions/checkout@v3 # 必要？
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.0'
-      - name: Install checkstyle_filter-git
-        run: gem install checkstyle_filter-git
-      - name: Run checkstyle_filter-git
-        run: checkstyle_filter-git diff origin/${{ github.base_ref }} ${{ needs.php-cs.outputs.outputs-on-phpcs }}
+          phpcs -q --report=checkstyle --standard=PSR12 ${{ steps.git-diff-changed-files.outputs.changed_files }} \
+          | checkstyle_filter-git diff origin/${{ github.base_ref }}

--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Run phpcs # 名前変更
         id: reported-checkstyle-with-phpcs # いらん
         run: |
-          phpcs -q --report=checkstyle --standard=PSR12 ${{ steps.git-diff-changed-files.outputs.changed_files }} \
+          git diff --name-only origin/${{ github.base_ref }} HEAD -- '*.php' \
+          | xargs phpcs -q --report=checkstyle --standard=PSR12 \
           | checkstyle_filter-git diff origin/${{ github.base_ref }} \
           | cs2pr

--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -21,6 +21,6 @@ jobs:
       #   run: git fetch origin ${{ github.base_ref }} --depth=1
       - name: Git diff
         id: git-diff-changed-files
-        run: echo "changed_files=git diff --name-only origin/${{ github.base_ref }} HEAD -- '*.php'" >> $GITHUB_OUTPUT
+        run: echo "changed_files=$(git diff --name-only origin/${{ github.base_ref }} HEAD -- '*.php')" >> $GITHUB_OUTPUT
       - name: Echo
         run: echo ${{ steps.git-diff-changed-files.outputs.changed_files }}

--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -8,18 +8,16 @@ on:
       - '**.php'
 
 jobs:
-  php-cs: # 1つのジョブでやるなら、名前変更？
-    name: PHP CS of changed files # 1つのジョブでやるなら、名前変更？
+  php-cs-for-diff-lines:
+    name: PHP CS for diff lines
     runs-on: ubuntu-latest
-    outputs: # いらん
-      outputs-on-phpcs: ${{ steps.reported-checkstyle-with-phpcs.outputs.reported-checkstyle }}
     steps:
       - uses: actions/checkout@v3
-      - name: Setup PHP
+      - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.1'
-          tools: cs2pr, phpcs # cs2prいらんか？
+          tools: cs2pr, phpcs
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -28,13 +26,7 @@ jobs:
         run: gem install checkstyle_filter-git
       - name: Fetch
         run: git fetch origin ${{ github.base_ref }} --depth=1
-      # - name: Git diff
-      #   id: git-diff-changed-files
-        # run: echo "changed_files=$(git diff --name-only origin/${{ github.base_ref }} HEAD -- '*.php')" >> $GITHUB_OUTPUT
-      # - name: Echo # 後々削除
-        # run: echo ${{ steps.git-diff-changed-files.outputs.changed_files }}
-      - name: Run phpcs # 名前変更
-        id: reported-checkstyle-with-phpcs # いらん
+      - name: Run phpcs & Display errors of diff lines
         run: |
           git diff --name-only origin/${{ github.base_ref }} HEAD -- '*.php' \
           | xargs phpcs -q --report=checkstyle --standard=PSR12 \

--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Run phpcs
         id: reported-checkstyle-with-phpcs
         run: |
-          echo 'reported-checkstyle<<\/' >> $GITHUB_OUTPUT
+          echo 'reported-checkstyle<<EOF' >> $GITHUB_OUTPUT
           phpcs -q --report=checkstyle --standard=PSR12 ${{ steps.git-diff-changed-files.outputs.changed_files }} >> $GITHUB_OUTPUT
-          echo '\/' >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
   checkstyle_filter-git:
     # name:
     runs-on: ubuntu-latest

--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -36,4 +36,5 @@ jobs:
         id: reported-checkstyle-with-phpcs # いらん
         run: |
           phpcs -q --report=checkstyle --standard=PSR12 ${{ steps.git-diff-changed-files.outputs.changed_files }} \
-          | checkstyle_filter-git diff origin/${{ github.base_ref }}
+          | checkstyle_filter-git diff origin/${{ github.base_ref }} \
+          | cs2pr

--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -16,7 +16,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.1'
-          tools: cs2pr, phpcs
+          tools: cs2pr, phpcs # cs2prいらんか？
       - name: Fetch
         run: git fetch origin ${{ github.base_ref }} --depth=1
       - name: Git diff

--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Run phpcs
         id: reported-checkstyle-with-phpcs
         run: |
-          echo 'reported-checkstyle<<EOF' >> $GITHUB_OUTPUT
+          echo 'reported-checkstyle<<</file>' >> $GITHUB_OUTPUT
           phpcs -q --report=checkstyle --standard=PSR12 ${{ steps.git-diff-changed-files.outputs.changed_files }} >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
+          echo '</file>' >> $GITHUB_OUTPUT
   checkstyle_filter-git:
     # name:
     runs-on: ubuntu-latest

--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Run phpcs
         id: reported-checkstyle-with-phpcs
         run: |
-          echo 'reported-checkstyle<<</file></checkstyle>' >> $GITHUB_OUTPUT
+          echo 'reported-checkstyle<<EOF' >> $GITHUB_OUTPUT
           echo "$(phpcs -q --report=checkstyle --standard=PSR12 ${{ steps.git-diff-changed-files.outputs.changed_files }})" >> $GITHUB_OUTPUT
-          echo '</file></checkstyle>' >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
   checkstyle_filter-git:
     # name:
     runs-on: ubuntu-latest

--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Run phpcs
         id: reported-checkstyle-with-phpcs
         run: |
-          echo 'reported-checkstyle<<EOF' >> $GITHUB_OUTPUT
+          echo 'reported-checkstyle<<</file></checkstyle>' >> $GITHUB_OUTPUT
           echo "$(phpcs -q --report=checkstyle --standard=PSR12 ${{ steps.git-diff-changed-files.outputs.changed_files }})" >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
+          echo '</file></checkstyle>' >> $GITHUB_OUTPUT
   checkstyle_filter-git:
     # name:
     runs-on: ubuntu-latest

--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -1,5 +1,5 @@
 name: PHP CS for diff lines
-run-name: Pushed to ${{ github.event.pull_request.title }} by ${{ github.actor }}
+run-name: ${{ github.event.pull_request.title }} / by ${{ github.actor }}
 
 on:
   pull_request:

--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Run phpcs
         id: reported-checkstyle-with-phpcs
         run: |
-          echo 'reported-checkstyle<<</file>' >> $GITHUB_OUTPUT
+          echo 'reported-checkstyle<<\/' >> $GITHUB_OUTPUT
           phpcs -q --report=checkstyle --standard=PSR12 ${{ steps.git-diff-changed-files.outputs.changed_files }} >> $GITHUB_OUTPUT
-          echo '</file>' >> $GITHUB_OUTPUT
+          echo '\/' >> $GITHUB_OUTPUT
   checkstyle_filter-git:
     # name:
     runs-on: ubuntu-latest

--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -30,7 +30,7 @@ jobs:
         id: reported-checkstyle-with-phpcs
         run: |
           echo 'reported-checkstyle<<EOF' >> $GITHUB_OUTPUT
-          echo $(phpcs -q --report=checkstyle --standard=PSR12 ${{ steps.git-diff-changed-files.outputs.changed_files }}) >> $GITHUB_OUTPUT
+          echo "$(phpcs -q --report=checkstyle --standard=PSR12 ${{ steps.git-diff-changed-files.outputs.changed_files }})" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
   checkstyle_filter-git:
     # name:

--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -28,7 +28,10 @@ jobs:
         run: echo ${{ steps.git-diff-changed-files.outputs.changed_files }}
       - name: Run phpcs
         id: reported-checkstyle-with-phpcs
-        run: echo "reported-checkstyle=$(phpcs -q --report=checkstyle --standard=PSR12 ${{ steps.git-diff-changed-files.outputs.changed_files }})" >> $GITHUB_OUTPUT
+        run: |
+          echo 'reported-checkstyle<<EOF' >> $GITHUB_OUTPUT
+          phpcs -q --report=checkstyle --standard=PSR12 ${{ steps.git-diff-changed-files.outputs.changed_files }} >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
   checkstyle_filter-git:
     # name:
     runs-on: ubuntu-latest

--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -17,8 +17,8 @@ jobs:
         with:
           php-version: '8.1'
           tools: cs2pr, phpcs
-      # - name: Fetch
-      #   run: git fetch origin ${{ github.base_ref }} --depth=1
+      - name: Fetch
+        run: git fetch origin ${{ github.base_ref }} --depth=1
       - name: Git diff
         id: git-diff-changed-files
         run: echo "changed_files=$(git diff --name-only origin/${{ github.base_ref }} HEAD -- '*.php')" >> $GITHUB_OUTPUT

--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -30,7 +30,7 @@ jobs:
         id: reported-checkstyle-with-phpcs
         run: |
           echo 'reported-checkstyle<<EOF' >> $GITHUB_OUTPUT
-          phpcs -q --report=checkstyle --standard=PSR12 ${{ steps.git-diff-changed-files.outputs.changed_files }} >> $GITHUB_OUTPUT
+          echo $(phpcs -q --report=checkstyle --standard=PSR12 ${{ steps.git-diff-changed-files.outputs.changed_files }}) >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
   checkstyle_filter-git:
     # name:

--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -22,5 +22,5 @@ jobs:
       - name: Git diff
         id: git-diff-changed-files
         run: echo "changed_files=$(git diff --name-only origin/${{ github.base_ref }} HEAD -- '*.php')" >> $GITHUB_OUTPUT
-      - name: Echo
+      - name: Echo # 後々削除
         run: echo ${{ steps.git-diff-changed-files.outputs.changed_files }}

--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -7,10 +7,10 @@ on:
       - '**.php'
 
 jobs:
-  php-cs:
-    name: PHP CS of changed files
+  php-cs: # 1つのジョブでやるなら、名前変更？
+    name: PHP CS of changed files # 1つのジョブでやるなら、名前変更？
     runs-on: ubuntu-latest
-    outputs:
+    outputs: # いらん
       outputs-on-phpcs: ${{ steps.reported-checkstyle-with-phpcs.outputs.reported-checkstyle }}
     steps:
       - uses: actions/checkout@v3
@@ -32,8 +32,8 @@ jobs:
         run: echo "changed_files=$(git diff --name-only origin/${{ github.base_ref }} HEAD -- '*.php')" >> $GITHUB_OUTPUT
       - name: Echo # 後々削除
         run: echo ${{ steps.git-diff-changed-files.outputs.changed_files }}
-      - name: Run phpcs
-        id: reported-checkstyle-with-phpcs
+      - name: Run phpcs # 名前変更
+        id: reported-checkstyle-with-phpcs # いらん
         run: |
           phpcs -q --report=checkstyle --standard=PSR12 ${{ steps.git-diff-changed-files.outputs.changed_files }} \
           | checkstyle_filter-git diff origin/${{ github.base_ref }}

--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -1,0 +1,26 @@
+name: PHP CS for diff lines
+
+on:
+  pull_request:
+    # branches:
+    paths:
+      - '**.php'
+
+jobs:
+  php-cs:
+    name: PHP CS of changed files
+    runs-on: ubuntu-latest
+    steps:
+      # - uses: actions/checkout@v3
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: cs2pr, phpcs
+      # - name: Fetch
+      #   run: git fetch origin ${{ github.base_ref }} --depth=1
+      - name: Git diff
+        id: git-diff-changed-files
+        run: echo "changed_files=git diff --name-only origin/${{ github.base_ref }} HEAD -- '*.php'" >> $GITHUB_OUTPUT
+      - name: Echo
+        run: echo ${{ steps.git-diff-changed-files.outputs.changed_files }}

--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -27,11 +27,11 @@ jobs:
         run: gem install checkstyle_filter-git
       - name: Fetch
         run: git fetch origin ${{ github.base_ref }} --depth=1
-      - name: Git diff
-        id: git-diff-changed-files
-        run: echo "changed_files=$(git diff --name-only origin/${{ github.base_ref }} HEAD -- '*.php')" >> $GITHUB_OUTPUT
-      - name: Echo # 後々削除
-        run: echo ${{ steps.git-diff-changed-files.outputs.changed_files }}
+      # - name: Git diff
+      #   id: git-diff-changed-files
+        # run: echo "changed_files=$(git diff --name-only origin/${{ github.base_ref }} HEAD -- '*.php')" >> $GITHUB_OUTPUT
+      # - name: Echo # 後々削除
+        # run: echo ${{ steps.git-diff-changed-files.outputs.changed_files }}
       - name: Run phpcs # 名前変更
         id: reported-checkstyle-with-phpcs # いらん
         run: |

--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -11,7 +11,7 @@ jobs:
     name: PHP CS of changed files
     runs-on: ubuntu-latest
     steps:
-      # - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/php-cs-diff-lines.yml
+++ b/.github/workflows/php-cs-diff-lines.yml
@@ -29,3 +29,16 @@ jobs:
       - name: Run phpcs
         id: reported-checkstyle-with-phpcs
         run: echo "reported-checkstyle=$(phpcs -q --report=checkstyle --standard=PSR12 ${{ steps.git-diff-changed-files.outputs.changed_files }})" >> $GITHUB_OUTPUT
+  checkstyle_filter-git:
+    # name:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3 # 必要？
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.0'
+      - name: Install checkstyle_filter-git
+        run: gem install checkstyle_filter-git
+      - name: Run checkstyle_filter-git
+        run: checkstyle_filter-git diff origin/${{ github.base_ref }} ${{ needs.php-cs.outputs.outputs-on-phpcs }}


### PR DESCRIPTION
## タスクリンク

* なし

## やったこと

下記流れをGitHub Actionsで実行
* 差分のあるphpファイルの名前を取得（複数ファイル対応）
* 上記phpファイルを、`phpcs`でコーディングスタイルをチェックする（差分行含め、全体のエラーを出力）
* 上記`phpcs`の出力から、差分行のエラーのみを抽出
* 上記抽出した差分行のエラーをFile changedに表示する

## やらないこと

* 下記2件のIssueの解決
https://github.com/piyokintv/hayasaka/issues/5
https://github.com/piyokintv/hayasaka/issues/6

## できるようになること（ユーザ目線）

* phpファイルをプッシュ時、GitHub Actionsにて差分行のみのコーディングスタイルチェックを確認できる

## できなくなること（ユーザ目線）

* なし

## UIスクショ

### 変更前

 * なし

### 変更後

![github com_piyokintv_hayasaka_pull_3_files (1)](https://user-images.githubusercontent.com/76191551/208032495-9bc86f70-d8aa-48d5-8bf1-437ec43bae54.png)

![github com_piyokintv_hayasaka_pull_3_files](https://user-images.githubusercontent.com/76191551/208033703-f80a9589-5e8a-4731-bb18-9fb88950d6cd.png)


## 動作確認

下記テスト用プルリクで実験確認
https://github.com/piyokintv/hayasaka/pull/3

- [x] phpファイルを変更していない場合、GitHub Actionsが発火しない
- [x] phpファイルを1つ以上、変更した場合、GitHub Actionsが発火する
- [x] phpファイルの差分行にコーディングスタイルのエラーがあれば、File changedに表示される
（11個以上エラーがあっても、表示されるエラーは10個まで）
- [x] File changedに表示されているエラーを解決していくと、表示されていないエラーが次々表示される
（エラーが1〜13まであった場合、最初に表示されるのは1〜10まで
1、2、3を解決すると、4〜13が表示される）
- [x] phpファイルの差分行にコーディングスタイルのエラーがなければ、「All checks have passed」になる
（ファイル全体にコーディングスタイルエラーがあっても）


## その他

* なし
